### PR TITLE
Update for IntelliJ version 2021.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,12 +11,8 @@ changelog {
   version = '0.0.1'
 }
 
-runPluginVerifier {
-  ideVersions(pluginVerifierIdeVersions)
-}
-
 group 'org.intellij.sdk'
-version '2.1.0'
+version '3.0.0'
 
 sourceCompatibility = 1.8
 
@@ -27,7 +23,7 @@ repositories {
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 // Need version 2020.2 for JCEF support
 intellij {
-  version = '2021.1'
+  version = '2021.2'
 }
 
 buildSearchableOptions {
@@ -37,7 +33,7 @@ buildSearchableOptions {
 patchPluginXml {
   version = project.version
   sinceBuild = '202'
-  untilBuild = '211.*'
+  untilBuild = '212.*'
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,12 +3,9 @@
 
 pluginGroup = com.github.jstruk.mobtimeplugin
 pluginName_ = mobtime-plugin
-pluginVersion = 0.0.1
+pluginVersion = 3.0.0
 pluginSinceBuild = 201
-pluginUntilBuild = 211.*
-# Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
-# See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.1.4, 2020.2.4, 2020.3.2, 2021.1
+pluginUntilBuild = 212.*
 
 platformType = IC
 platformVersion = 2020.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,6 +12,7 @@
     <change-notes>
         <![CDATA[
       <ul>
+        <li><b>3.0.0</b> Support IntelliJ 2021.2 </li>
         <li><b>2.1.0</b> Support IntelliJ EAP 2021.1 </li>
         <li><b>2.0.2</b> Stable Release </li>
         <li><b>2.0.1</b> Update Icon </li>
@@ -22,7 +23,7 @@
 
     <depends>com.intellij.modules.platform</depends>
 
-    <idea-version since-build="202.6397.25" until-build="211.*" />
+    <idea-version since-build="202.6397.25" until-build="212.*" />
 
     <!-- Text to display as company information on Preferences/Settings | Plugin page -->
     <vendor url="https://mobti.me/">Mobtime</vendor>


### PR DESCRIPTION
* Update dependencies
* runPluginVerifier was causing the build to fail with the new gradle and platform versions. Removing for now (runPluginVerifier does not have test against versions of IntelliJ currently, anyway)